### PR TITLE
Fix: Correct NUI focus handling for role selection

### DIFF
--- a/client.lua
+++ b/client.lua
@@ -184,15 +184,15 @@ AddEventHandler('cnr:updatePlayerData', function(newPlayerData)
     end
 end)
 
-RegisterNetEvent('cnr:setNuiFocus')
-AddEventHandler('cnr:setNuiFocus', function(data)
-    if type(data) == "table" and data.hasFocus ~= nil and data.hasCursor ~= nil then
-        print(string.format("[CNR_CLIENT] Setting NUI focus via event: hasFocus=%s, hasCursor=%s", tostring(data.hasFocus), tostring(data.hasCursor)))
-        SetNuiFocus(data.hasFocus, data.hasCursor)
-    else
-        print(string.format("[CNR_CLIENT_WARN] cnr:setNuiFocus received invalid data: %s", json.encode and json.encode(data) or tostring(data)))
-    end
-end)
+-- RegisterNetEvent('cnr:setNuiFocus')
+-- AddEventHandler('cnr:setNuiFocus', function(data)
+--     if type(data) == "table" and data.hasFocus ~= nil and data.hasCursor ~= nil then
+--         print(string.format("[CNR_CLIENT] Setting NUI focus via event: hasFocus=%s, hasCursor=%s", tostring(data.hasFocus), tostring(data.hasCursor)))
+--         SetNuiFocus(data.hasFocus, data.hasCursor)
+--     else
+--         print(string.format("[CNR_CLIENT_WARN] cnr:setNuiFocus received invalid data: %s", json.encode and json.encode(data) or tostring(data)))
+--     end
+-- end)
 
 function CalculateXpForNextLevelClient(currentLevel, playerRole)
     if not Config.LevelingSystemEnabled then return 999999 end
@@ -630,6 +630,17 @@ end)
 RegisterNUICallback('getPlayerInventory', function(data, cb)
     if RequestInventoryForNUI then RequestInventoryForNUI(cb)
     else print("Error: RequestInventoryForNUI function not found.", "error"); cb({ error = "Internal error: Inventory system not available." }) end
+end)
+
+RegisterNUICallback('setNuiFocus', function(data, cb)
+    if type(data) == "table" and data.hasFocus ~= nil and data.hasCursor ~= nil then
+        print(string.format("[CNR_CLIENT] Setting NUI focus via NUI callback: hasFocus=%s, hasCursor=%s", tostring(data.hasFocus), tostring(data.hasCursor)))
+        SetNuiFocus(data.hasFocus, data.hasCursor)
+        cb('ok')
+    else
+        print(string.format("[CNR_CLIENT_WARN] NUI callback 'setNuiFocus' received invalid data: %s", json.encode and json.encode(data) or tostring(data)))
+        cb('error') -- Or cb({status='error', message='Invalid data'})
+    end
 end)
 
 Citizen.CreateThread(function()

--- a/html/scripts.js
+++ b/html/scripts.js
@@ -146,8 +146,8 @@ window.addEventListener('message', function(event) {
 async function fetchSetNuiFocus(hasFocus, hasCursor) {
     try {
         const resName = window.cnrResourceName || 'cops-and-robbers';
-        console.log('[CNR_NUI] Attempting to fetchSetNuiFocus. URL:', `https://\${resName}/cnr:setNuiFocus`);
-        await fetch(`https://\${resName}/cnr:setNuiFocus`, {
+  console.log('[CNR_NUI] Attempting to fetchSetNuiFocus. URL:', `https://\${resName}/setNuiFocus`);
+  await fetch(`https://\${resName}/setNuiFocus`, {
             method: 'POST',
             headers: { 'Content-Type': 'application/json; charset=UTF-8' },
             body: JSON.stringify({ hasFocus: hasFocus, hasCursor: hasCursor })


### PR DESCRIPTION
The NUI was attempting to set focus using an incorrect fetch URL (`https://\${resName}/cnr:setNuiFocus`) which didn't correspond to a registered NUI callback in client.lua. Instead, client.lua had a net event handler for `cnr:setNuiFocus`.

This commit addresses the issue by:
1. Modifying `html/scripts.js`:
   - Changed the `fetchSetNuiFocus` function to use the URL `https://\${resName}/setNuiFocus`. This removes the 'cnr:' prefix and aligns with standard NUI callback naming.
2. Modifying `client.lua`:
   - Removed the old `RegisterNetEvent('cnr:setNuiFocus')`.
   - Added `RegisterNUICallback('setNuiFocus', ...)`. This new callback now correctly handles the request from NUI to set the focus using `SetNuiFocus()`.

These changes ensure that the NUI properly communicates with the client script to set focus, resolving the "TypeError: Failed to fetch" and allowing the role selection menu to appear as intended.