### PR TITLE
Fix 'end' statement syntax errors - add proper line separators

### DIFF
--- a/admin.lua
+++ b/admin.lua
@@ -91,7 +91,9 @@ RegisterCommand("ban", function(source, args, rawCommand)
 
     if not reason or reason == "" then
         reason = "No reason provided."
-    end    if targetId and IsValidPlayer(targetId) then
+    end
+    
+    if targetId and IsValidPlayer(targetId) then
         TriggerServerEvent('cops_and_robbers:logAdminCommand', GetSafePlayerName(source), source, rawCommand) -- Log before action
         -- Trigger server event to handle the ban
         TriggerServerEvent('cops_and_robbers:banPlayer', targetId, reason)
@@ -182,7 +184,9 @@ RegisterCommand("reassign", function(source, args, rawCommand)
     if not IsAdmin(source) then
         TriggerClientEvent('chat:addMessage', source, { args = { "^1System", "You do not have permission to use this command." } })
         return
-    end    local targetIdStr = args[1]
+    end
+    
+    local targetIdStr = args[1]
     local targetId = tonumber(targetIdStr)
     local newRole = args[2]   -- Should be "cop" or "robber"
 
@@ -254,7 +258,9 @@ RegisterCommand("triggerbankheist", function(source, args, rawCommand)
     if not bankId then
         TriggerClientEvent('chat:addMessage', source, { args = { "^1Admin", "Usage: /triggerbankheist <bankId>" } })
         return
-    end    TriggerServerEvent('cops_and_robbers:logAdminCommand', GetSafePlayerName(source), source, rawCommand)
+    end
+    
+    TriggerServerEvent('cops_and_robbers:logAdminCommand', GetSafePlayerName(source), source, rawCommand)
     TriggerServerEvent('cops_and_robbers:adminTriggerBankHeist', bankId)
     TriggerClientEvent('chat:addMessage', source, { args = { "^1Admin", "Bank heist event triggered for bank ID: " .. bankId } })
 end, false)
@@ -269,7 +275,9 @@ RegisterCommand("triggerstorerobbery", function(source, args, rawCommand)
     if not storeId then
         TriggerClientEvent('chat:addMessage', source, { args = { "^1Admin", "Usage: /triggerstorerobbery <storeId>" } })
         return
-    end    TriggerServerEvent('cops_and_robbers:logAdminCommand', GetSafePlayerName(source), source, rawCommand)
+    end
+    
+    TriggerServerEvent('cops_and_robbers:logAdminCommand', GetSafePlayerName(source), source, rawCommand)
     TriggerServerEvent('cops_and_robbers:adminTriggerStoreRobbery', storeId)
     TriggerClientEvent('chat:addMessage', source, { args = { "^1Admin", "Store robbery event triggered for store ID: " .. storeId } })
 end, false)
@@ -284,7 +292,9 @@ RegisterCommand("triggerpoweroutage", function(source, args, rawCommand)
     if not gridId then
         TriggerClientEvent('chat:addMessage', source, { args = { "^1Admin", "Usage: /triggerpoweroutage <gridId>" } })
         return
-    end    TriggerServerEvent('cops_and_robbers:logAdminCommand', GetSafePlayerName(source), source, rawCommand)
+    end
+    
+    TriggerServerEvent('cops_and_robbers:logAdminCommand', GetSafePlayerName(source), source, rawCommand)
     TriggerServerEvent('cops_and_robbers:adminTriggerPowerOutage', gridId)
     TriggerClientEvent('chat:addMessage', source, { args = { "^1Admin", "Power outage event triggered for grid ID: " .. gridId } })
 end, false)
@@ -307,10 +317,14 @@ RegisterCommand("setlevel", function(source, args, rawCommand)
     if not IsValidPlayer(targetId) then
         TriggerClientEvent('chat:addMessage', source, { args = { "^1Admin", "Invalid player ID." } })
         return
-    end    if newLevel < 1 or newLevel > 100 then
+    end
+    
+    if newLevel < 1 or newLevel > 100 then
         TriggerClientEvent('chat:addMessage', source, { args = { "^1Admin", "Level must be between 1 and 100." } })
         return
-    end    TriggerEvent('cops_and_robbers:logAdminCommand', GetSafePlayerName(source), source, rawCommand)
+    end
+    
+    TriggerEvent('cops_and_robbers:logAdminCommand', GetSafePlayerName(source), source, rawCommand)
     TriggerEvent('cops_and_robbers:adminSetLevel', targetId, newLevel)
 
     TriggerClientEvent('chat:addMessage', source, {

--- a/client.lua
+++ b/client.lua
@@ -719,7 +719,9 @@ function UpdateRobberStoreBlips()
     if type(Config.NPCVendors) ~= "table" or (getmetatable(Config.NPCVendors) and getmetatable(Config.NPCVendors).__name == "Map") then
         print("[CNR_CLIENT_ERROR] UpdateRobberStoreBlips: Config.NPCVendors is not an array. Cannot iterate.")
         return
-    end    for i, vendor in ipairs(Config.NPCVendors) do
+    end
+    
+    for i, vendor in ipairs(Config.NPCVendors) do
         if not vendor then
             print(string.format("[CNR_CLIENT_WARN] UpdateRobberStoreBlips: Nil vendor entry at index %d.", i))
             goto continue_robber_blips_loop

--- a/server.lua
+++ b/server.lua
@@ -1391,7 +1391,8 @@ AddEventHandler('cops_and_robbers:getItemList', function(storeType, vendorItemId
     if Config.Items and type(Config.Items) == 'table' then
         for _, itemIdFromVendor in ipairs(vendorItemIds) do
             local foundItem = nil
-            for _, configItem in ipairs(Config.Items) do                if configItem.itemId == itemIdFromVendor then
+            for _, configItem in ipairs(Config.Items) do
+                if configItem.itemId == itemIdFromVendor then
                     -- Create a new table for the item to send, ensuring all necessary fields are present
                     foundItem = {
                         itemId = configItem.itemId,
@@ -1815,7 +1816,9 @@ AddEventHandler('cops_and_robbers:sellItem', function(itemId, quantity)
             itemConfig = cfgItem
             break
         end
-    end    if not itemConfig or not itemConfig.sellPrice then
+    end
+    
+    if not itemConfig or not itemConfig.sellPrice then
         -- Send failure response to NUI
         TriggerClientEvent('cnr:sendNUIMessage', src, {
             action = 'sellResult',


### PR DESCRIPTION
This pull request focuses on improving code readability and maintainability by ensuring consistent formatting across multiple functions in `admin.lua`, `client.lua`, and `server.lua`. The changes primarily involve adding line breaks to separate conditional blocks and subsequent logic, making the code easier to read and debug.

### Code readability improvements:

* **`admin.lua`:** Added line breaks after conditional statements in multiple admin command functions (`ban`, `reassign`, `triggerbankheist`, `triggerstorerobbery`, `triggerpoweroutage`, and `setlevel`) to separate logic blocks for better readability. [[1]](diffhunk://#diff-167e1254e427d7fdaa69ba76a1c2614f8153da987c7e1792ae311346a3379a80L94-R96) [[2]](diffhunk://#diff-167e1254e427d7fdaa69ba76a1c2614f8153da987c7e1792ae311346a3379a80L185-R189) [[3]](diffhunk://#diff-167e1254e427d7fdaa69ba76a1c2614f8153da987c7e1792ae311346a3379a80L257-R263) [[4]](diffhunk://#diff-167e1254e427d7fdaa69ba76a1c2614f8153da987c7e1792ae311346a3379a80L272-R280) [[5]](diffhunk://#diff-167e1254e427d7fdaa69ba76a1c2614f8153da987c7e1792ae311346a3379a80L287-R297) [[6]](diffhunk://#diff-167e1254e427d7fdaa69ba76a1c2614f8153da987c7e1792ae311346a3379a80L310-R327)

* **`client.lua`:** Added a line break in `UpdateRobberStoreBlips` to separate the conditional check from the subsequent loop logic.

* **`server.lua`:** Improved formatting in `cops_and_robbers:getItemList` and `cops_and_robbers:sellItem` by adding line breaks after conditional checks to clearly delineate logic blocks. [[1]](diffhunk://#diff-1b8f97d898e63162c92a0f09152d067cbe6a053a3fe5d96b96d751cbacce5786L1394-R1395) [[2]](diffhunk://#diff-1b8f97d898e63162c92a0f09152d067cbe6a053a3fe5d96b96d751cbacce5786L1818-R1821)